### PR TITLE
Fix TofHit::from_bytestream and u32tof32 methods

### DIFF
--- a/tof/dataclasses/C++/src/events.cxx
+++ b/tof/dataclasses/C++/src/events.cxx
@@ -1007,7 +1007,8 @@ TofHit TofHit::from_bytestream(const Vec<u8> &bytestream,
    hit.charge_a_f32  = Gaps::parse_f16(bytestream, pos); 
    hit.charge_b_f32  = Gaps::parse_f16(bytestream, pos); 
    hit.charge_min_i  = Gaps::parse_u16(bytestream, pos); 
-   //hit.baseline         = Gaps::parse_u16(bytestream, pos); 
+   //hit.baseline         = Gaps::parse_u16(bytestream, pos);
+   hit.x_pos         = Gaps::parse_u16(bytestream, pos); 
    hit.t_average     = Gaps::parse_u16(bytestream, pos); 
    hit.ctr_etx       = bytestream[pos]; pos+=1;
    hit.timestamp32   = Gaps::parse_u32(bytestream, pos);

--- a/tof/dataclasses/C++/src/parsers.cxx
+++ b/tof/dataclasses/C++/src/parsers.cxx
@@ -48,12 +48,13 @@ u32 leading_zeros(u16 x) {
 //lil' helpa
 f32 u32tof32(u32 val) {
   f32 result;
-  Vec<u8> bytes = Vec<u8>();
+  Vec<u8> bytes = Vec<u8>(4);
   bytes[3] = (val >> 24) & 0xFF;
   bytes[2] = (val >> 16) & 0xFF;
   bytes[1] = (val >> 8)  & 0xFF;
   bytes[0] =  val & 0xFF;
   std::memcpy(&result, bytes.data(), sizeof(f32));
+  return result;
 }
 
 /***********************************************/


### PR DESCRIPTION
Fix a segfault from u32tof32 function (missing return value and vector size).
Also fix from_bytestream method of TofHit (the decoding of x_pos was missing).