### PR TITLE
Hit quality classification

### DIFF
--- a/gondola-core/C++/include/events.h
+++ b/gondola-core/C++/include/events.h
@@ -30,6 +30,8 @@
 #include "packets/tof_packet.h"
 #include "events/event_status.hpp"
 #include "events/rb_event_header.hpp"
+#include "events/hit_quality.hpp"
+#include "events/post_flight_correction_functions.hpp"
 #include "events/tof_hit.hpp"
 #include "events/rb_event.hpp"
 #include "events/event_quality.hpp"

--- a/gondola-core/C++/include/events/hit_quality.hpp
+++ b/gondola-core/C++/include/events/hit_quality.hpp
@@ -1,0 +1,77 @@
+/// This file is part of gaps-online-software and published
+/// under the GPLv3 license
+// only ever include this header once per compilation unit,
+// even if multiple files #include it
+#pragma once
+
+// std::format / std::formatter - needed for the formatter
+// specialization at the bottom of this file
+#include <format>
+// std::ostringstream - used by the formatter to capture the
+// output of operator<< into a string
+#include <sstream>
+
+// basic typedefs (u8, f32, Vec, ...) via tof_typedefs.h
+#include "gondola.hpp"
+
+// everything in gaps-online-software C++ lives in the
+// gondola namespace
+namespace gondola {
+
+  struct TofHit;
+
+  enum class HitQuality : u8 {
+    // hit has not been classified (yet)
+    Unknown           =  0,
+    //$$$$$ Reserved for future use, nothing sets these yet.
+    Mangled           =  1,
+    MissingHit        =  2,
+    //$$$$$
+    LowPedPlusPedRMS  =  3, // abs(ped) > 1 and pedRMS > 2 (jeff's cut)
+    LowRMSgrThree     =  4, // rms > 3 (box2 cut)
+    LowElenaCuts      =  5, // cuts where really the analysis failed.
+    Low               = 10, // general Low status
+
+    MidPedRMS         = 11, // middle triangular region in peak vs rms for coincidence pulses (box1 cut)
+    MidPos            = 12, // hit position too close to a paddle end
+    MidPedRMSandPos   = 13, // MidPedRMS and MidPos both apply
+    MidPosSat         = 14, // position issue on an otherwise-saturated pulse; ped cuts don't apply to saturated pulses
+    Mid               = 20, // general Mid status
+
+    HighSat           = 21, // High, but the pulse is saturated (> 600 mV)
+    High              = 30, // general High status
+    // between mid and high, really just techincally high hits
+    // but could use some sort of recalibration...
+    // like a noisy saturated pulse for example
+    ReprocessHighSat  = 31,
+    ReprocessHigh     = 40,
+    // same as ReprocessHigh, but the pulse is also saturated (tot725 filled)
+  };
+
+  // Implemented in src/events.cxx
+  auto classify_hit(const TofHit& hit) -> HitQuality;
+
+  // Implemented in src/events.cxx
+  std::ostream& operator<<(std::ostream& os, const gondola::HitQuality& quality);
+}
+
+
+template <>
+
+struct std::formatter<gondola::HitQuality> : std::formatter<std::string> {
+  constexpr auto parse(std::format_parse_context& ctx) {
+      return ctx.begin();
+  }
+
+  // format() does the actual conversion of a HitQuality value
+  // into characters written to the output (ctx.out())
+  auto format(const gondola::HitQuality& quality, auto& ctx) const {
+      // an in-memory output stream to write into
+      std::ostringstream oss;
+      // reuse operator<< (see above) so the printed text is the
+      // same for std::cout and std::format
+      oss << quality;
+      // copy the accumulated string into the formatter's output
+      return std::format_to(ctx.out(), "{}", oss.str());
+  }
+};

--- a/gondola-core/C++/include/events/hit_quality.hpp
+++ b/gondola-core/C++/include/events/hit_quality.hpp
@@ -36,6 +36,8 @@ namespace gondola {
     MidPos            = 12, // hit position too close to a paddle end
     MidPedRMSandPos   = 13, // MidPedRMS and MidPos both apply
     MidPosSat         = 14, // position issue on an otherwise-saturated pulse; ped cuts don't apply to saturated pulses
+    MidPosSatReprocess= 15,
+    MidPosReprocess   = 16,
     Mid               = 20, // general Mid status
 
     HighSat           = 21, // High, but the pulse is saturated (> 600 mV)

--- a/gondola-core/C++/include/events/post_flight_correction_functions.hpp
+++ b/gondola-core/C++/include/events/post_flight_correction_functions.hpp
@@ -1,0 +1,28 @@
+/// This file is part of gaps-online-software and published
+/// under the GPLv3 license
+#pragma once
+
+#include "gondola.hpp"
+
+namespace gondola {
+
+  /// Corrections applied post-flight to quantities that were computed
+  /// online without access to the full raw waveform (e.g. a fast
+  /// baseline rms estimate). Each function here undoes a specific,
+  /// known bias of its no-waveform online counterpart.
+  namespace postFlightCorrectionFunctions {
+
+    /// Correct a no-waveform baseline rms estimate for the bias
+    /// introduced by a nonzero mean mu over a window of num samples.
+    ///
+    /// Implemented in src/events.cxx
+    ///
+    /// @param mu   : online-estimated mean of the baseline window
+    /// @param sigB : online-estimated (biased) rms of the baseline window
+    /// @param num  : number of samples the online estimate was taken over
+    ///
+    /// @returns the corrected rms, or NaN if the correction is undefined
+    ///          (negative radicand or non-finite intermediate value)
+    auto corrected_rms_noWF(f32 mu, f32 sigB, u32 num = 200) -> f32;
+  }
+}

--- a/gondola-core/C++/include/events/tof_hit.hpp
+++ b/gondola-core/C++/include/events/tof_hit.hpp
@@ -5,8 +5,8 @@
 #include "result/result.h"
 
 #include "database.h"
-#include "version.h" 
-#include "events/event_quality.hpp"
+#include "version.h"
+#include "events/hit_quality.hpp"
 
 namespace r = result;
 
@@ -24,7 +24,7 @@ namespace gondola {
   
     // new variables for V1
     ProtocolVersion version;
-    EventQuality quality = EventQuality::Unknown;;
+    HitQuality quality = HitQuality::Unknown;
     f32 baseline_a;
     f32 baseline_a_rms;
     f32 baseline_b;

--- a/gondola-core/C++/src/events.cxx
+++ b/gondola-core/C++/src/events.cxx
@@ -420,16 +420,229 @@ namespace gondola {
          os << "Diamond>";
          break;
        }
-       case g::EventQuality::FourLeafClover : { 
+       case g::EventQuality::FourLeafClover : {
          os << "FourLeafClover>";
          break;
        }
      }
      return os;
   }
-    
+
   /**********************************************************/
-  
+
+  std::ostream& operator<<(std::ostream& os, const g::HitQuality& quality) {
+     os << "<HitQuality: " ;
+     switch (quality) {
+       case g::HitQuality::Unknown : {
+         os << "Unknown>";
+         break;
+       }
+       case g::HitQuality::Mangled : {
+         os << "Mangled>";
+         break;
+       }
+       case g::HitQuality::MissingHit : {
+         os << "MissingHit>";
+         break;
+       }
+       case g::HitQuality::LowPedPlusPedRMS : {
+         os << "LowPedPlusPedRMS>";
+         break;
+       }
+       case g::HitQuality::LowRMSgrThree : {
+         os << "LowRMSgrThree>";
+         break;
+       }
+       case g::HitQuality::LowElenaCuts : {
+         os << "LowElenaCuts>";
+         break;
+       }
+       case g::HitQuality::Low : {
+         os << "Low>";
+         break;
+       }
+       case g::HitQuality::MidPedRMS : {
+         os << "MidPedRMS>";
+         break;
+       }
+       case g::HitQuality::MidPos : {
+         os << "MidPos>";
+         break;
+       }
+       case g::HitQuality::MidPedRMSandPos : {
+         os << "MidPedRMSandPos>";
+         break;
+       }
+       case g::HitQuality::MidPosSat : {
+         os << "MidPosSat>";
+         break;
+       }
+       case g::HitQuality::Mid : {
+         os << "Mid>";
+         break;
+       }
+       case g::HitQuality::HighSat : {
+         os << "HighSat>";
+         break;
+       }
+       case g::HitQuality::High : {
+         os << "High>";
+         break;
+       }
+       case g::HitQuality::ReprocessHigh : {
+         os << "ReprocessHigh>";
+         break;
+       }
+       case g::HitQuality::ReprocessHighSat : {
+         os << "ReprocessHighSat>";
+         break;
+       }
+     }
+     return os;
+  }
+
+  /**********************************************************/
+
+  namespace {
+    // Domains derived from the "side rms vs peak" study (40h dataset):
+    //  * rms <  RMS_GOOD_MAX                       -> unconditionally good (High)
+    //  * rms >= RMS_LOW_MIN                         -> unconditionally bad  (Low), any peak
+    //  * RMS_GOOD_MAX <= rms < RMS_LOW_MIN          -> "correctable" triangle: a large
+    //    peak (good S/N) can still compensate for the elevated baseline noise. The
+    //    triangle's hypotenuse runs from (RMS_GOOD_MAX, peak=0) to (RMS_LOW_MIN, PEAK_REF),
+    //    so hits on/right of it (low peak relative to rms) are Mid, the rest stay High.
+    constexpr f32 RMS_GOOD_MAX = 1.8f;
+    constexpr f32 RMS_LOW_MIN  = 3.0f;
+    constexpr f32 PEAK_REF     = 600.0f;
+    constexpr f32 PED_REF_JEFF     = 1.0f;
+    constexpr f32 PEDRMS_REF_JEFF     = 2.0f;
+
+
+    constexpr f32 RMS_REPROCESS_MIN = 1.7f;
+
+    // Placeholder
+    constexpr f32 POS_CUT_LENGTH_MM = 100.0f;
+
+    //classifies side behavior
+    auto classify_side(f32 rms, f32 peak, f32 ped, f32 tot725) -> g::HitQuality {
+
+      // +++++  large pulse IFs +++++
+      if ((tot725 != 0) && (rms > RMS_REPROCESS_MIN))
+      {
+        return g::HitQuality::ReprocessHighSat;
+      }
+      else if (tot725 != 0) {
+        return g::HitQuality::HighSat;
+      }
+
+      if ((peak > PEAK_REF) && (rms > RMS_REPROCESS_MIN))
+      {
+        return g::HitQuality::ReprocessHigh;
+      }
+      else if (peak > PEAK_REF) {
+        return g::HitQuality::High;
+      }
+      // +++++  END large pulse IFs +++++
+
+      f32 boundary = RMS_GOOD_MAX + (RMS_LOW_MIN - RMS_GOOD_MAX) * (peak / PEAK_REF);
+      //mid and low side classificaiton
+      if (rms >= RMS_LOW_MIN) { // box2 cuts
+        return g::HitQuality::LowRMSgrThree;
+      }
+      else if ((rms >= PEDRMS_REF_JEFF) && (std::abs(ped) >= PED_REF_JEFF)) { // jeff's cuts
+        return g::HitQuality::LowPedPlusPedRMS;
+      }
+      if (rms >= boundary) { //coincidence (box1) cuts
+        return g::HitQuality::MidPedRMS;
+      }
+      //anything else will be a good pulse...
+
+      return g::HitQuality::High;
+    }
+
+    // true if the hit's reconstructed position sits away from both paddle
+    // ends by at least POS_CUT_LENGTH_MM. Everything in this function is
+    // kept in mm - paddle_len is stored in cm, so it's converted once here.
+    auto position_ok(const g::TofHit& hit) -> bool {
+      f32 paddle_len_mm = 10.0f * hit.paddle_len;
+      f32 half_len_mm   = paddle_len_mm / 2.0f;
+      f32 x_pos_mm      = hit.get_x_pos(); // already mm
+      return (x_pos_mm > -half_len_mm + POS_CUT_LENGTH_MM) && (x_pos_mm < half_len_mm - POS_CUT_LENGTH_MM);
+    }
+  }
+
+  auto postFlightCorrectionFunctions::corrected_rms_noWF(f32 mu, f32 sigB, u32 num) -> f32 {
+    f32 n   = static_cast<f32>(num);
+    f32 val = ((n - mu*mu) / n) * (sigB*sigB) - mu*mu;
+    if (!std::isfinite(val) || val < 0.0f) {
+      return std::numeric_limits<f32>::quiet_NaN();
+    }
+    return std::sqrt(val);
+  }
+
+  /**********************************************************/
+
+  auto classify_hit(const g::TofHit& hit) -> g::HitQuality {
+    //hit obeys causality
+    if (!hit.obeys_causality()) {
+      return g::HitQuality::Low;
+    }
+    // #### ped RMS and Ped classificaiton... ####
+    // (uncorrected) rms if the correction is undefined (NaN)
+    f32 baseline_a_correction = postFlightCorrectionFunctions::corrected_rms_noWF(hit.baseline_a, hit.baseline_a_rms);
+    f32 baseline_b_correction = postFlightCorrectionFunctions::corrected_rms_noWF(hit.baseline_b, hit.baseline_b_rms);
+    // this will be fixed by grace, keep the correction now...
+    if (!std::isfinite(baseline_a_correction)) {
+      baseline_a_correction = hit.baseline_a_rms;
+    }
+    if (!std::isfinite(baseline_b_correction)) {
+      baseline_b_correction = hit.baseline_b_rms;
+    }
+    auto quality_a = classify_side(baseline_a_correction, hit.get_peak_a(), hit.baseline_a, hit.tot_high_a);
+    auto quality_b = classify_side(baseline_b_correction, hit.get_peak_b(), hit.baseline_b, hit.tot_high_b);
+
+    // a side already in the High family (High/HighSat/ReprocessHigh/ReprocessHighSat)
+    // reflects a large/saturated pulse on that side, and shouldn't be dragged
+    // down to Low/Mid.
+    auto is_high_family = [](g::HitQuality q) {
+      return q == g::HitQuality::High || q == g::HitQuality::HighSat
+          || q == g::HitQuality::ReprocessHigh || q == g::HitQuality::ReprocessHighSat;
+    };
+
+    bool a_saturated = is_high_family(quality_a);
+    bool b_saturated = is_high_family(quality_b);
+    g::HitQuality quality;
+    if (a_saturated != b_saturated) {
+      quality = a_saturated ? quality_a : quality_b;
+    } else {
+      // both saturated, or neither the worse side wins
+      quality = std::min(quality_a, quality_b);
+    }
+
+    // #### paddle position classification... ####
+    // position cuts only ever demote a Mid/High verdict further into Mid
+    // an already-Low hit stays Low regardless of where it reconstructs
+    if (!position_ok(hit)) {
+      switch (quality) {
+        case g::HitQuality::MidPedRMS:
+          quality = g::HitQuality::MidPedRMSandPos;
+          break;
+        case g::HitQuality::HighSat:
+          quality = g::HitQuality::MidPosSat;
+          break;
+        case g::HitQuality::High:
+          quality = g::HitQuality::MidPos;
+          break;
+        default:
+          break;
+      }
+    }
+
+    return quality;
+  }
+
+  /**********************************************************/
+
   std::ostream& operator<<(std::ostream& os, const g::CompressionLevel& level) {
      os << "<CompressionLevel: " ;
      switch (level) {
@@ -1341,7 +1554,7 @@ auto g::TofHit::from_bytestream(const Vec<u8> &bytestream, u64 &pos)
    return Err(err);
  }
  u8 quality_version_u8     = g::parse_u8(bytestream, ver_pos);
- hit.quality               = static_cast<EventQuality>(quality_version_u8 & 0x3f);
+ hit.quality               = static_cast<HitQuality>(quality_version_u8 & 0x3f);
  hit.version               = (g::ProtocolVersion)(quality_version_u8 & 0xc0);
  //u8  version        = g::parse_u8(bytestream, ver_pos);
  //hit.version        = (g::ProtocolVersion) version;

--- a/gondola-core/C++/src/events.cxx
+++ b/gondola-core/C++/src/events.cxx
@@ -477,6 +477,14 @@ namespace gondola {
          os << "MidPosSat>";
          break;
        }
+       case g::HitQuality::MidPosSatReprocess : {
+         os << "MidPosSatReprocess>";
+         break;
+       }
+       case g::HitQuality::MidPosReprocess : {
+         os << "MidPosReprocess>";
+         break;
+       }
        case g::HitQuality::Mid : {
          os << "Mid>";
          break;
@@ -560,14 +568,14 @@ namespace gondola {
       return g::HitQuality::High;
     }
 
-    // true if the hit's reconstructed position sits away from both paddle
-    // ends by at least POS_CUT_LENGTH_MM. Everything in this function is
-    // kept in mm - paddle_len is stored in cm, so it's converted once here.
+
+    // NB: get_x_pos() is measured from end A (x=0) to end B (x=paddle_len_mm),
+    // not centered on the paddle - see get_edep()/sd_legacy.cxx for the same
+    // convention.
     auto position_ok(const g::TofHit& hit) -> bool {
       f32 paddle_len_mm = 10.0f * hit.paddle_len;
-      f32 half_len_mm   = paddle_len_mm / 2.0f;
       f32 x_pos_mm      = hit.get_x_pos(); // already mm
-      return (x_pos_mm > -half_len_mm + POS_CUT_LENGTH_MM) && (x_pos_mm < half_len_mm - POS_CUT_LENGTH_MM);
+      return (x_pos_mm > POS_CUT_LENGTH_MM) && (x_pos_mm < paddle_len_mm - POS_CUT_LENGTH_MM);
     }
   }
 
@@ -583,23 +591,33 @@ namespace gondola {
   /**********************************************************/
 
   auto classify_hit(const g::TofHit& hit) -> g::HitQuality {
+
+    //fatal analysis cuts...
     //hit obeys causality
     if (!hit.obeys_causality()) {
       return g::HitQuality::Low;
     }
+    // #### Elena's cuts - cases where the analysis itself failed ####
+    if (hit.baseline_a == 0 || hit.get_time_a() == 0
+     || hit.baseline_b == 0 || hit.get_time_b() == 0
+     || hit.get_time_a() > 350 || hit.get_time_b() > 350) {
+      return g::HitQuality::LowElenaCuts;
+    }
+
+
     // #### ped RMS and Ped classificaiton... ####
     // (uncorrected) rms if the correction is undefined (NaN)
-    f32 baseline_a_correction = postFlightCorrectionFunctions::corrected_rms_noWF(hit.baseline_a, hit.baseline_a_rms);
-    f32 baseline_b_correction = postFlightCorrectionFunctions::corrected_rms_noWF(hit.baseline_b, hit.baseline_b_rms);
+    f32 baseline_a_rms_correction = postFlightCorrectionFunctions::corrected_rms_noWF(hit.baseline_a, hit.baseline_a_rms);
+    f32 baseline_b_rms_correction = postFlightCorrectionFunctions::corrected_rms_noWF(hit.baseline_b, hit.baseline_b_rms);
     // this will be fixed by grace, keep the correction now...
-    if (!std::isfinite(baseline_a_correction)) {
-      baseline_a_correction = hit.baseline_a_rms;
+    if (!std::isfinite(baseline_a_rms_correction)) {
+      baseline_a_rms_correction = hit.baseline_a_rms;
     }
-    if (!std::isfinite(baseline_b_correction)) {
-      baseline_b_correction = hit.baseline_b_rms;
+    if (!std::isfinite(baseline_b_rms_correction)) {
+      baseline_b_rms_correction = hit.baseline_b_rms;
     }
-    auto quality_a = classify_side(baseline_a_correction, hit.get_peak_a(), hit.baseline_a, hit.tot_high_a);
-    auto quality_b = classify_side(baseline_b_correction, hit.get_peak_b(), hit.baseline_b, hit.tot_high_b);
+    auto quality_a = classify_side(baseline_a_rms_correction, hit.get_peak_a(), hit.baseline_a, hit.tot_high_a);
+    auto quality_b = classify_side(baseline_b_rms_correction, hit.get_peak_b(), hit.baseline_b, hit.tot_high_b);
 
     // a side already in the High family (High/HighSat/ReprocessHigh/ReprocessHighSat)
     // reflects a large/saturated pulse on that side, and shouldn't be dragged
@@ -611,6 +629,7 @@ namespace gondola {
 
     bool a_saturated = is_high_family(quality_a);
     bool b_saturated = is_high_family(quality_b);
+
     g::HitQuality quality;
     if (a_saturated != b_saturated) {
       quality = a_saturated ? quality_a : quality_b;
@@ -633,6 +652,13 @@ namespace gondola {
         case g::HitQuality::High:
           quality = g::HitQuality::MidPos;
           break;
+        case g::HitQuality::ReprocessHighSat:
+          quality = g::HitQuality::MidPosSatReprocess;
+          break;
+        case g::HitQuality::ReprocessHigh:
+          quality = g::HitQuality::MidPosReprocess;
+          break;
+
         default:
           break;
       }
@@ -1371,7 +1397,9 @@ auto g::TofEvent::to_string() const -> std::string {
 /*************************************/
 
 void g::TofHit::set_paddle_len(f32 paddle_len) {
-  paddle_len = paddle_len;
+  // was this, but does this cause a collision without this?
+  //paddle_len = paddle_len;
+  this->paddle_len = paddle_len;
 }
 
 /*************************************/


### PR DESCRIPTION
Logic, flags, and cut values are finalized for hit classification. 

A few fyis: renamed event quality to hit quality to reduce later confusion.

for poistion cuts I used the convention that sideA = 0 and sideB = 180 cm (for a 180 long paddle). It was using the 
middle of the paddle = 0, but noticed in tof-hit that was not the case, so I wanted to make it consistent... 

Also noticed a possible collision due to degenerate naming in a paddle length function, so I changed paddle_len to this->paddle_len... so if I am wrong, just ignore that diff. 

Other than this, everything should be complete! Let me know if you need any more input...